### PR TITLE
Setup Google Analytics tracking tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,6 +44,22 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <script
+          async
+          src="https://www.googletagmanager.com/gtag/js?id=G-TF69GDGZMB"
+        />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'G-TF69GDGZMB');
+            `,
+          }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
Google Analytics tracking was implemented by modifying `src/app/layout.tsx`.

The Google Analytics `gtag.js` script and its configuration were added directly within the `<head>` section of the root layout.

*   The `gtag.js` script was included asynchronously from `https://www.googletagmanager.com/gtag/js?id=G-TF69GDGZMB`.
*   The initialization script, including `window.dataLayer` setup, `gtag` function definition, and `gtag('config', 'G-TF69GDGZMB')`, was embedded using `dangerouslySetInnerHTML`.

This approach ensures the Google Analytics tag is present on every page, enabling comprehensive tracking across the application. The direct script inclusion was chosen to circumvent a linter/type error encountered when attempting to use `next/script` for this specific implementation.